### PR TITLE
Break command into two subcommands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,9 @@ Project and Build Status
      :target: https://ci.appveyor.com/project/glenjarvis/github_commit_status/branch/master
      :alt: Windows build status on Appveyor
 
-* GitHub repo: https://github.com/glenjarvis/github_commit_status/
-* Documentation: `Read The Docs <https://github_commit_status.readthedocs.io/>`_
-* Free software: `LICENSE <https://github.com/glenjarvis/github_commit_status/blob/master/LICENSE>`_
+* `GitHub repo <https://github.com/glenjarvis/github_commit_status/>`_
+* `Online Documentation <https://github-commit-status.readthedocs.io/en/latest/readme.html>`_
+* `Free Software <https://github.com/glenjarvis/github_commit_status/blob/master/LICENSE>`_
 
 
 How to Use
@@ -145,14 +145,14 @@ Choose **Personal access tokens**:
    even if you don't want them to.
 
 
-Example: When needed rarely
----------------------------
+Example: Prompt mode
+--------------------
 
 If you only need to use this comand line rarely, there's no need to worry about
 getting the command line arguments correct - you will be prompted for any
 required arguments that are missing. This is ideal for students in my class who
 only need to update a Pull Requests a few times for a homework assignment. See
-the next section for a more scriptable and professional example.
+the next section for a more scriptable mode and example.
 
 
 1. Install::
@@ -161,7 +161,7 @@ the next section for a more scriptable and professional example.
 
 2. Run::
 
-     github_commit_status
+     github_commit_status prompt
 
 3. Enter the data that you have collected (e.g., Personal Access Token, commit
    SHA, etc.)
@@ -170,22 +170,31 @@ the next section for a more scriptable and professional example.
    your Personal Access Token get published like I intentionally did here. I
    ensured this token was deleted before I published this::
 
-     $ github_commit_status
-     Github token []: 26fee6a5d440111a2648312d458b6b4e44c20c1d
-     Name of the GitHub repository []: experiment_20180525
+     $ github_commit_status prompt
+
+     GitHub Token [26fee6a5d440111a2648312d458b6b4e44c20c1d]:
+     Name of the GitHub repository []: my_target_repo
      Commit SHA []: 2dd5f9ce1108d69e863444ee6486e64e0299868f
      Status: pending
-     Description: Tests are running
+     Description: Tests have started
+
      GitHub has been updated.
 
 
 Example: For scripting
 ----------------------
 
-This command can also be used for shell scripts that need to update GitHub. In
-this example, we include the Personal Access Token as a command line option.
-That's not as secure, since the shell keeps a history of your commands. See the
-next example for a better option.
+This command can also be used for shell scripts that need to update GitHub.
+
+For security reasons, this mode/subcommand does not provide an option for::
+
+    --github-token
+
+as this is preserved in most shell histories. Instead, the
+environment variable *GITHUB_COMMIT_STATUS_TOKEN* should already be set. For
+example, in a bash shell::
+
+  export GITHUB_COMMIT_STATUS_TOKEN=26fee6a5d440111a2648312d458b6...
 
 
 1. Install::
@@ -194,79 +203,27 @@ next example for a better option.
 
 2. To see command line options that can be provided::
 
-    $ github_commit_status --help
-    Usage: github_commit_status [OPTIONS]
+    $ github_commit_status update --help
+    Usage: github_commit_status update [OPTIONS]
 
-      Update GitHub with the arguments given
-
-    Options:
-      --github-token TEXT
-      --repo TEXT                     Name of the GitHub repository
-      --commit TEXT                   The 40 character SHA1 string for the commit.
-      --status [error|failure|pending|success]
-                                      The status of the commit
-      --description TEXT              Description for the test
-      --version
-      --help                          Show this message and exit.
-
-3. Here is an example usage. Remember, using your Personal Access Token
-   on the command line isn't as secure::
-
-      $ github_commit_status --status=failure --description="There are failed tests." --commit=2dd5f9ce1108d69e863444ee6486e64e0299868f --repo=experiment_20180525 --github-token=26fee6a5d440111a2648312d458b6b4e44c20c1d
-
-
-Example: Scripting with better security
----------------------------------------
-
-This command can be used for shell scripts to update GitHub without including
-the Personal Access Token as an option. If GitHub token (e.g., your Personal
-Access Token) isn't provided, this command will look for the token in the
-**GITHUB_COMMIT_STATUS_TOKEN** environment variable.
-
-
-1. Install::
-
-     pip install github_commit_status
-
-2. Export the GITHUB_COMMIT_STATUS_TOKEN. For example, in the Bash shell::
-
-     export GITHUB_COMMIT_STATUS_TOKEN=26fee6a5d440111a2648312d458b6b4e44c20c1d
-
-3. To see command line options that can be provided::
-
-    $ github_commit_status --help
-    Usage: github_commit_status [OPTIONS]
-
-      Update GitHub with the arguments given
+      If all options are provided, update GitHub
 
     Options:
-      --github-token TEXT
-      --repo TEXT                     Name of the GitHub repository
+      --repo TEXT                     Name of the GitHub repository  [required]
       --commit TEXT                   The 40 character SHA1 string for the commit.
+                                      [required]
       --status [error|failure|pending|success]
-                                      The status of the commit
-      --description TEXT              Description for the test
-      --version
+                                      The status of the commit  [required]
+      --description TEXT              Description for the test  [required]
       --help                          Show this message and exit.
 
+3. Here is an example usage. Remember, your Personal Access Token
+   needs to be pre-set in environment variable **GITHUB_COMMIT_STATUS_TOKEN**::
 
-4. Here is an example usage. However, we simply neglect to include the::
-
-     --github-token
-
-   argument as we have already set the **GITHUB_COMMIT_STATUS_TOKEN**
-   environment variable::
-
-      $ github_commit_status --repo=experiment_20180525 --commit=2dd5f9ce1108d69e863444ee6486e64e0299868f --status=success --description="All tests passed."
-      GitHub Token [26fee6a5d440111a2648312d458b6b4e44c20c1d]:
-      GitHub has been updated.
-
-   This currently still displays the GitHub Access Token on the screen, but it
-   is not recorded into your shell's history. In future versions of this command
-   line, we will prevent the Personal Access Token from displaying on the screen
-   as well. `Lucky Issue #13
-   <https://github.com/glenjarvis/github_commit_status/issues/13>`_ is used to
-   track the status of this change
+      $ github_commit_status update --repo=my_target_repo \
+          --commit="2dd5f9ce1108d69e863444ee6486e64e0299868f" \
+          --status=pending \
+          --description="Tests are running."
 
 
 Make this better by Contributing

--- a/github_commit_status/cli.py
+++ b/github_commit_status/cli.py
@@ -1,11 +1,10 @@
 #!python
 # -*- coding: utf-8 -*-
 
-"""Update Status of GitHub to simulate a CI Server response
+"""Update Status of a commit in GitHub
 
-This tool will update GitHub status for a given commit SHA1. The
-following information needs to be given to GitHub so that the update can
-happen:
+This tool will update the GitHub status for a given commit SHA1. The
+following information needs to be given so that the update can happen:
 
     - GitHub Token. Personal Access Token (from Developer Settings) to
       give command access to update GitHub repo. See documentation for
@@ -27,6 +26,32 @@ happen:
         o success
 
     - A short description
+
+There are two modes for this command: prompt and update
+
+Prompt
+------
+This command line was originally written as a learning exercise for a
+beginner course. This allows prompting for options if not provided to
+make this command easier to use. To enable this mode, use the subcommand
+"prompt".
+
+Example::
+
+    $ github_commit_status prompt
+
+Update
+------
+This command can be very useful as component of a shell script. To
+enable this functionality without the prompting, use the subcommand
+"update".
+
+Example::
+
+    $ github_commit_status update --repo=my_target_repo \
+          --commit="2dd5f9ce1108d69e863444ee6486e64e0299868f" \
+          --status=pending \
+          --description="Tests are running."
 """
 
 import os
@@ -35,6 +60,7 @@ import click
 from github import Github
 
 VERSION = "1.0.3"
+INVALID_TOKEN = "Invalid GitHub Token"
 
 
 def update_github(repo_name, github_token, commit, status, description):
@@ -52,6 +78,22 @@ def update_github(repo_name, github_token, commit, status, description):
     click.echo("GitHub has been updated.")
 
 
+def validate_commit_sha1(ctx, param, value):
+    """Validate value is a valid SHA1"""
+    # params ctx, param passed by click but not needed here
+    # pylint: disable=unused-argument
+
+    if len(value) > 40:
+        raise click.BadParameter("commit should be less than 40 characters")
+
+    try:
+        int(value, 16)
+    except ValueError:
+        raise click.BadParameter("commit should be hexadecimal")
+
+    return value
+
+
 def print_version(ctx, param, value):
     """Find version from file VERSION and print"""
 
@@ -63,6 +105,14 @@ def print_version(ctx, param, value):
     ctx.exit()
 
 
+@click.group()
+@click.option('--version', is_flag=True, callback=print_version,
+              expose_value=False, is_eager=True)
+def cli():
+    """Update the status of a commit in GitHub"""
+    pass
+
+
 # pylint: disable=no-value-for-parameter
 @click.command()
 @click.option('--github-token', prompt='GitHub Token',
@@ -70,7 +120,7 @@ def print_version(ctx, param, value):
 @click.option('--repo', prompt='Name of the GitHub repository',
               default=lambda: os.environ.get('GITHUB_COMMIT_STATUS_REPO', ''),
               help='Name of the GitHub repository')
-@click.option('--commit', prompt='Commit SHA',
+@click.option('--commit', callback=validate_commit_sha1, prompt='Commit SHA',
               default=lambda: os.environ.get('GITHUB_COMMIT_STATUS_COMMIT'),
               help='The 40 character SHA1 string for the commit.')
 @click.option('--status',
@@ -78,15 +128,59 @@ def print_version(ctx, param, value):
               help='The status of the commit', prompt=True)
 @click.option('--description', prompt='Description',
               help='Description for the test')
-@click.option('--version', is_flag=True, callback=print_version,
-              expose_value=False, is_eager=True)
-def main(repo, github_token, commit, status, description):
-    """Update GitHub with the arguments given"""
+def prompt(repo, github_token, commit, status, description):
+    """Prompt for missing options and update GitHub
+
+    Example:
+      $ github_commit_status prompt
+      GitHub Token [26fee6a5d440111a2648312d458b6b4e44c20c1d]:
+      Name of the GitHub repository []: my_target_repo
+      Commit SHA []: 2dd5f9ce1108d69e863444ee6486e64e0299868f
+      Status: pending
+      Description: Tests have started
+
+      GitHub has been updated.
+    """
     update_github(repo, github_token, commit, status, description)
 
 
-if __name__ == '__main__':
-    main()  # pragma: no cover
+@click.command()
+@click.option('--repo', required=True,
+              help='Name of the GitHub repository')
+@click.option('--commit', callback=validate_commit_sha1, required=True,
+              help='The 40 character SHA1 string for the commit.')
+@click.option('--status', required=True,
+              type=click.Choice(['error', 'failure', 'pending', 'success']),
+              help='The status of the commit')
+@click.option('--description', required=True, help='Description for the test')
+def update(repo, commit, status, description):
+    """If all options are provided, update GitHub
 
-# TOOD: Validate SHA is 40 characters
-# Make github token hidden
+    For security reasons, this subcommand does not provide an option for
+    `--github-token` as this is preserved in most shell histories.
+
+    Instead, the environment variable `GITHUB_COMMIT_STATUS_TOKEN`
+    should already be set. For example, in a bash shell::
+
+      export GITHUB_COMMIT_STATUS_TOKEN=26fee6a5d440111a2648312d458b6...
+
+    Token must be provided as part of the environment, it cannot be
+    given as part of a command line option for security reasons.
+
+    Example:
+     $ github_commit_status update --repo=my_target_repo \\
+           --commit="2dd5f9ce1108d69e863444ee6486e64e0299868f" \\
+            --status=pending
+           --description="Tests are running."
+    """
+    github_token = os.environ.get('GITHUB_COMMIT_STATUS_TOKEN', INVALID_TOKEN)
+    update_github(repo, github_token, commit, status, description)
+
+
+# Subcommands
+cli.add_command(prompt)
+cli.add_command(update)
+
+
+if __name__ == '__main__':
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,11 @@ from setuptools import setup, find_packages
 with open('README.rst') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
-    history = history_file.read()
-
 requirements = ['Click>=6.0', "pygithub"]
 
-setup_requirements = [ ]
+setup_requirements = []
 
-test_requirements = [ ]
+test_requirements = []
 
 setup(
     author="Glen Jarvis",
@@ -23,6 +20,8 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Education',
+        'Intended Audience :: Developers',
+        'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
@@ -32,10 +31,10 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    description="A simple command line for updating a GitHub status",
+    description="A simple command line for updating a commit's status on GitHub",
     entry_points={
         'console_scripts': [
-            'github_commit_status=github_commit_status.cli:main',
+            'github_commit_status=github_commit_status.cli:cli',
         ],
     },
     install_requires=requirements,

--- a/tests/test_github_commit_status.py
+++ b/tests/test_github_commit_status.py
@@ -6,17 +6,26 @@
 import unittest
 from click.testing import CliRunner
 
-#from github_commit_status import github_commit_status
 from github_commit_status import cli
+
+# These names are from unittest conventions. Ignore
+# pylint: disable=invalid-name
 
 
 class TestGithub_commit_status(unittest.TestCase):
     """Tests for `github_commit_status` package."""
 
+    SAMPLE_SETTINGS = ['--repo=sample_repo',
+                       '--status=pending',
+                       '--description="Tests started"']
+
     def setUp(self):
         """Call CLI with --help"""
         self.runner = CliRunner()
-        self.help_result = self.runner.invoke(cli.main, ['--help'])
+        self.help_result = self.runner.invoke(cli.cli, ['--help'])
+        self.version_result = self.runner.invoke(cli.cli, ['--version'])
+        self.prompt_result = self.runner.invoke(cli.cli, ['prompt', '--help'])
+        self.update_result = self.runner.invoke(cli.cli, ['update', '--help'])
 
     def test_cli_help(self):
         """It responds properly to --help"""
@@ -24,30 +33,87 @@ class TestGithub_commit_status(unittest.TestCase):
         self.assertTrue('Show this message and exit.' in
                         self.help_result.output)
 
-    def test_cli_github_token(self):
+    def test_cli_version(self):
+        """It responds properly to --version"""
+        self.assertEqual(self.version_result.exit_code, 0)
+        self.assertTrue('Version' in
+                        self.version_result.output)
+
+    def test_cli_subcommands(self):
+        """It has subcommands prompt and update"""
+        self.assertEqual(self.help_result.exit_code, 0)
+        self.assertTrue('prompt  Prompt for missing options' in
+                        self.help_result.output)
+        self.assertTrue('update  If all options are provided' in
+                        self.help_result.output)
+
+    def test_cli_prompt_github_token(self):
         """It responds to --github-token argument"""
 
-        self.assertTrue('--github-token TEXT' in self.help_result.output)
+        self.assertTrue('--github-token TEXT' in self.prompt_result.output)
 
-    def test_cli_github_repo(self):
+    def test_cli_prompt_github_repo(self):
         """It responds to --repo argument"""
 
-        self.assertTrue('--repo TEXT' in  self.help_result.output)
+        self.assertTrue('--repo TEXT' in self.prompt_result.output)
 
-    def test_cli_github_commit(self):
+    def test_cli_prompt_github_commit(self):
         """It responds to --commit argument"""
 
-        self.assertTrue('--commit TEXT' in  self.help_result.output)
+        self.assertTrue('--commit TEXT' in self.prompt_result.output)
 
-    def test_cli_github_status(self):
+    def test_cli_prompt_github_status(self):
         """It responds to --status argument"""
 
         self.assertTrue('--status [error|failure|pending|success]' in
-                        self.help_result.output)
+                        self.prompt_result.output)
 
-
-    def test_cli_github_description(self):
+    def test_cli_prompt_github_description(self):
         """It responds to --description argument"""
 
-        self.assertTrue('--description TEXT' in  self.help_result.output)
+        self.assertTrue('--description TEXT' in self.prompt_result.output)
 
+    def test_cli_update_github_token(self):
+        """It does not respond to --github-token argument"""
+
+        self.assertFalse('--github-token TEXT' in self.update_result.output)
+
+    def test_cli_update_github_repo(self):
+        """It responds to --repo argument"""
+
+        self.assertTrue('--repo TEXT' in self.update_result.output)
+
+    def test_cli_update_github_commit(self):
+        """It responds to --commit argument"""
+
+        self.assertTrue('--commit TEXT' in self.update_result.output)
+
+    def test_cli_update_github_status(self):
+        """It responds to --status argument"""
+
+        self.assertTrue('--status [error|failure|pending|success]' in
+                        self.update_result.output)
+
+    def test_cli_update_github_description(self):
+        """It responds to --description argument"""
+
+        self.assertTrue('--description TEXT' in self.update_result.output)
+
+    def test_cli_update_github_commit_length(self):
+        """It ensures --commit argument is less than 40 characters"""
+
+        commit_chars = "123456789abcdef0"*3
+        args_opts = ['update', '--commit={}'.format(commit_chars)]
+        args_opts.extend(self.SAMPLE_SETTINGS)
+        result = self.runner.invoke(cli.cli, args_opts)
+        self.assertTrue('commit should be less than 40 characters' in
+                        result.output)
+
+    def test_cli_update_github_commit_hex(self):
+        """It ensures --commit argument only accepts hexadecimal"""
+
+        args_opts = ['update', '--commit=1g']
+        args_opts.extend(self.SAMPLE_SETTINGS)
+        result = self.runner.invoke(cli.cli, args_opts)
+        self.assertTrue('commit should be hexadecimal' in
+                        result.output)


### PR DESCRIPTION
There are two different modes of audience consumption, so match those
modes with subcommands: prompt and update

Fix: #13