### PR TITLE
Use the poetry generated dev requirements for Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,4 @@ formats: all
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
There are conflicting ideas about package management. We see Pyenv and
Poetry bumping up against the older ideas of unstructured
requirements.txt. (I do wish we could have our own custom sections of
requirements in Poetry and Pyenv).

Instead of breaking DRY to create a custom (but more focused/cleaner)
requirements for documentation building, let's just use the generated
--dev requirements from poetry.