### PR TITLE
Explain why we are constraining `pip` in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Constrain pip version (pip-tools compatibility)
       run: |
-        pip install "pip<25.3"
+        pip install "pip<25.3" # See https://github.com/jazzband/pip-tools/issues/2252
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
See Pull Request https://github.com/glenjarvis/github-commit-status/pull/968  for explanation. This will be fixed with `pip-tools` current development is actually releaed.