### PR TITLE
Bump Python version for ReadTheDocs to 3.12

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.12"
 
 python:
   install:


### PR DESCRIPTION
This moves it from supported but not yet newer version of Python