### PR TITLE
Ensure the cli version matches pyproject.toml

### DIFF
--- a/github_commit_status/cli.py
+++ b/github_commit_status/cli.py
@@ -51,16 +51,15 @@ Example::
 """
 
 import os
+from importlib.metadata import PackageNotFoundError, version
 
 import click
 from github import Github
 
 try:
-    from importlib.metadata import version
     VERSION = version("github_commit_status")
-except Exception:
+except PackageNotFoundError:
     VERSION = "unknown"
-
 INVALID_TOKEN = "Invalid GitHub Token"
 
 


### PR DESCRIPTION
There should be only one location for the version. It should be in the pyproject.toml file. The CLI needs to dynamically read from the pyproject.toml file